### PR TITLE
Endpoints Update and Delete for Problem

### DIFF
--- a/apps/problems/api.py
+++ b/apps/problems/api.py
@@ -3,8 +3,6 @@ from ninja import Router, Status
 from django.core.exceptions import ValidationError
 from ninja.errors import HttpError
 from apps.problems.exceptions import ProblemNotFound
-from .schemas import ProblemSchema, ProblemCreateSchema
-from .models import Problem
 from .schemas import ProblemSchema, ProblemCreateSchema, ProblemUpdateSchema
 from .services import ProblemService
 
@@ -36,19 +34,23 @@ def create_problem(request, data: ProblemCreateSchema):
 @router.patch('/{problem_id}/', response=ProblemSchema)
 def update_problem(request, problem_id: UUID, data: ProblemUpdateSchema):
     try:
-        problem = ProblemService.get_problem_by_id(problem_id)
+        problem = ProblemService.get_problem_for_update_or_delete(problem_id)
         updated_problem = ProblemService.update_problem(
             problem,
             **data.model_dump(exclude_unset=True)
         )
         return updated_problem
-    except Problem.DoesNotExist:
+    except ProblemNotFound:
         raise HttpError(404, 'Problem not found')
+    except ValidationError as e:
+        raise HttpError(422, e.messages[0])
+
 
 @router.delete('/{problem_id}/', response={204: None})
 def delete_problem(request, problem_id: UUID):
     try:
-        ProblemService.deactivate_problem(problem_id)
+        problem = ProblemService.get_problem_for_update_or_delete(problem_id)
+        ProblemService.deactivate_problem(problem)
         return Status(204, None)
-    except Problem.DoesNotExist:
+    except ProblemNotFound:
         raise HttpError(404, 'Problem not found')

--- a/apps/problems/api.py
+++ b/apps/problems/api.py
@@ -3,7 +3,7 @@ from ninja import Router, Status
 from django.core.exceptions import ValidationError
 from ninja.errors import HttpError
 from .models import Problem
-from .schemas import ProblemSchema, ProblemCreateSchema
+from .schemas import ProblemSchema, ProblemCreateSchema, ProblemUpdateSchema
 from .services import ProblemService
 
 router = Router()
@@ -29,3 +29,24 @@ def create_problem(request, data: ProblemCreateSchema):
         return Status(201, new_problem)
     except ValidationError as e:
         raise HttpError(422, e.messages[0])
+
+
+@router.patch('/{problem_id}/', response=ProblemSchema)
+def update_problem(request, problem_id: UUID, data: ProblemUpdateSchema):
+    try:
+        problem = ProblemService.get_problem_by_id(problem_id)
+        updated_problem = ProblemService.update_problem(
+            problem,
+            **data.model_dump(exclude_unset=True)
+        )
+        return updated_problem
+    except Problem.DoesNotExist:
+        raise HttpError(404, 'Problem not found')
+
+@router.delete('/{problem_id}/', response={204: None})
+def delete_problem(request, problem_id: UUID):
+    try:
+        ProblemService.deactivate_problem(problem_id)
+        return Status(204, None)
+    except Problem.DoesNotExist:
+        raise HttpError(404, 'Problem not found')

--- a/apps/problems/repositories.py
+++ b/apps/problems/repositories.py
@@ -26,8 +26,14 @@ class ProblemRepository:
         
         for field, value in fields.items():
             if field not in allowed_fields:
-                raise ValueError(f'Field {field} is not allowed to be updated.')
+                raise ValueError(f"Field {field} is not allowed to be updated.")
             # Apply only fields provided by the service layer.
             setattr(problem, field, value)
 
         return ProblemRepository.save(problem)
+
+    @staticmethod
+    def deactivate(problem: Problem) -> None:
+        problem.is_active = False
+        ProblemRepository.save(problem)
+       

--- a/apps/problems/repositories.py
+++ b/apps/problems/repositories.py
@@ -1,4 +1,4 @@
-import uuid
+from uuid import UUID
 from apps.problems.models import Problem
 
 
@@ -14,7 +14,11 @@ class ProblemRepository:
         return Problem.objects.filter(is_active=True)
 
     @staticmethod
-    def get_active_by_id(problem_id: uuid.UUID):
+    def get_by_id(problem_id: UUID) -> Problem:
+        return Problem.objects.get(id=problem_id)
+
+    @staticmethod
+    def get_active_by_id(problem_id: UUID) -> Problem:
         return Problem.objects.get(id=problem_id, is_active=True)
 
     @staticmethod
@@ -23,10 +27,10 @@ class ProblemRepository:
             return problem
 
         allowed_fields = {'title', 'description', 'difficulty', 'category'}
-        
+
         for field, value in fields.items():
             if field not in allowed_fields:
-                raise ValueError(f"Field {field} is not allowed to be updated.")
+                raise ValueError(f'Field {field} is not allowed to be updated.')
             # Apply only fields provided by the service layer.
             setattr(problem, field, value)
 
@@ -36,4 +40,3 @@ class ProblemRepository:
     def deactivate(problem: Problem) -> None:
         problem.is_active = False
         ProblemRepository.save(problem)
-       

--- a/apps/problems/schemas.py
+++ b/apps/problems/schemas.py
@@ -17,3 +17,9 @@ class ProblemCreateSchema(Schema):
     description: str
     difficulty: Literal['easy', 'medium', 'hard']
     category: str
+
+class ProblemUpdateSchema(Schema):
+    title: str | None = None
+    description: str | None = None
+    difficulty: Literal['easy', 'medium', 'hard'] | None = None
+    category: str | None = None

--- a/apps/problems/schemas.py
+++ b/apps/problems/schemas.py
@@ -18,6 +18,7 @@ class ProblemCreateSchema(Schema):
     difficulty: Literal['easy', 'medium', 'hard']
     category: str
 
+
 class ProblemUpdateSchema(Schema):
     title: str | None = None
     description: str | None = None

--- a/apps/problems/services.py
+++ b/apps/problems/services.py
@@ -1,4 +1,3 @@
-import uuid
 from uuid import UUID
 from django.core.exceptions import ValidationError
 from apps.problems.exceptions import ProblemNotFound
@@ -52,8 +51,7 @@ class ProblemService:
         return ProblemRepository.update(problem, **update_data)
 
     @staticmethod
-    def deactivate_problem(problem_id: UUID) -> None:
-        problem = ProblemRepository.get_active_by_id(problem_id)
+    def deactivate_problem(problem: Problem) -> None:
         ProblemRepository.deactivate(problem)
 
     @staticmethod
@@ -61,8 +59,15 @@ class ProblemService:
         return ProblemRepository.list_active()
 
     @staticmethod
-    def get_problem_by_id(problem_id: uuid.UUID) -> Problem:
+    def get_problem_by_id(problem_id: UUID) -> Problem:
         try:
             return ProblemRepository.get_active_by_id(problem_id)
+        except Problem.DoesNotExist as exc:
+            raise ProblemNotFound('Problem not found') from exc
+
+    @staticmethod
+    def get_problem_for_update_or_delete(problem_id: UUID) -> Problem:
+        try:
+            return ProblemRepository.get_by_id(problem_id)
         except Problem.DoesNotExist as exc:
             raise ProblemNotFound('Problem not found') from exc

--- a/apps/problems/services.py
+++ b/apps/problems/services.py
@@ -1,9 +1,10 @@
 import uuid
+from uuid import UUID
 from django.core.exceptions import ValidationError
 from .models import Problem, DIFFICULTY_CHOICES
 from .repositories import ProblemRepository
 
-VALID_DIFFICULTY_KEYS = [choice[0] for choice in DIFFICULTY_CHOICES]
+VALID_DIFFICULTY_KEYS = {choice[0] for choice in DIFFICULTY_CHOICES}
 
 
 class ProblemService:
@@ -50,9 +51,9 @@ class ProblemService:
         return ProblemRepository.update(problem, **update_data)
 
     @staticmethod
-    def deactivate_problem(problem: Problem) -> Problem:
-        problem.is_active = False
-        return ProblemRepository.save(problem)
+    def deactivate_problem(problem_id: UUID) -> None:
+        problem = ProblemRepository.get_active_by_id(problem_id)
+        ProblemRepository.deactivate(problem)
 
     @staticmethod
     def get_all_problems():

--- a/tests/problems/test_problem_api.py
+++ b/tests/problems/test_problem_api.py
@@ -11,17 +11,17 @@ client = TestClient(router)
 class TestProblemApi:
     def test_list_problems_should_return_only_active_problems(self):
         active_problem = Problem.objects.create(
-            title="Active problem",
-            description="Active description",
-            difficulty="easy",
-            category="arrays",
+            title='Active problem',
+            description='Active description',
+            difficulty='easy',
+            category='arrays',
             is_active=True,
         )
         Problem.objects.create(
-            title="Inactive problem",
-            description="Inactive description",
-            difficulty="medium",
-            category="strings",
+            title='Inactive problem',
+            description='Inactive description',
+            difficulty='medium',
+            category='strings',
             is_active=False,
         )
 
@@ -31,19 +31,19 @@ class TestProblemApi:
         data = response.json()
 
         assert len(data) == 1
-        assert data[0]["id"] == str(active_problem.id)
-        assert data[0]["title"] == "Active problem"
-        assert data[0]["description"] == "Active description"
-        assert data[0]["difficulty"] == "easy"
-        assert data[0]["category"] == "arrays"
-        assert data[0]["is_active"] is True
+        assert data[0]['id'] == str(active_problem.id)
+        assert data[0]['title'] == 'Active problem'
+        assert data[0]['description'] == 'Active description'
+        assert data[0]['difficulty'] == 'easy'
+        assert data[0]['category'] == 'arrays'
+        assert data[0]['is_active'] is True
 
     def test_get_problem_should_return_single_active_problem(self):
         problem = Problem.objects.create(
-            title="Binary Search",
-            description="Find target in sorted array",
-            difficulty="medium",
-            category="algorithms",
+            title='Binary Search',
+            description='Find target in sorted array',
+            difficulty='medium',
+            category='algorithms',
             is_active=True,
         )
 
@@ -52,51 +52,101 @@ class TestProblemApi:
         assert response.status_code == 200
         data = response.json()
 
-        assert data["id"] == str(problem.id)
-        assert data["title"] == "Binary Search"
-        assert data["description"] == "Find target in sorted array"
-        assert data["difficulty"] == "medium"
-        assert data["category"] == "algorithms"
-        assert data["is_active"] is True
+        assert data['id'] == str(problem.id)
+        assert data['title'] == 'Binary Search'
+        assert data['description'] == 'Find target in sorted array'
+        assert data['difficulty'] == 'medium'
+        assert data['category'] == 'algorithms'
+        assert data['is_active'] is True
 
     def test_get_problem_should_return_404_for_inactive_problem(self):
         problem = Problem.objects.create(
-            title="Hidden problem",
-            description="Should not be available",
-            difficulty="easy",
-            category="arrays",
+            title='Hidden problem',
+            description='Should not be available',
+            difficulty='easy',
+            category='arrays',
             is_active=False,
         )
 
         response = client.get(f"/{problem.id}/")
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Problem not found"
+        assert response.json()['detail'] == 'Problem not found'
 
     def test_get_problem_should_return_404_for_nonexistent_problem(self):
-        response = client.get("/11111111-1111-1111-1111-111111111111/")
+        response = client.get('/11111111-1111-1111-1111-111111111111/')
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Problem not found"
+        assert response.json()['detail'] == 'Problem not found'
 
     def test_create_problem_should_create_problem_and_return_201(self):
         payload = {
-            "title": "Two Sum",
-            "description": "Return indices of two numbers that add up to target",
-            "difficulty": "easy",
-            "category": "arrays",
+            'title': 'Two Sum',
+            'description': 'Return indices of two numbers that add up to target',
+            'difficulty': 'easy',
+            'category': 'arrays',
         }
 
-        response = client.post("/", json=payload)
+        response = client.post('/', json=payload)
 
         assert response.status_code == 201
         data = response.json()
 
-        assert data["title"] == payload["title"]
-        assert data["description"] == payload["description"]
-        assert data["difficulty"] == payload["difficulty"]
-        assert data["category"] == payload["category"]
-        assert data["is_active"] is True
+        assert data['title'] == payload['title']
+        assert data['description'] == payload['description']
+        assert data['difficulty'] == payload['difficulty']
+        assert data['category'] == payload['category']
+        assert data['is_active'] is True
 
         assert Problem.objects.count() == 1
-        assert Problem.objects.first().title == "Two Sum"
+        assert Problem.objects.first().title == 'Two Sum'
+
+    def test_delete_problem_should_deactivate_it_and_return_204(self, problem):
+        response = client.delete(f"/{problem.id}/")
+
+        assert response.status_code == 204
+
+        problem.refresh_from_db()
+
+        assert problem.is_active is False
+        assert Problem.objects.count() == 1
+        
+    def test_patch_problem_should_update_selected_fields(self, problem):
+        payload = {
+            'title': 'Updated title',
+            'difficulty': 'hard',
+            'category': 'update'
+        }
+
+        response = client.patch(f"/{problem.id}/", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['title'] == 'Updated title'
+        assert data['difficulty'] == 'hard'
+        assert data['category'] == 'update'
+
+        problem.refresh_from_db()
+        assert problem.title == 'Updated title'
+        assert problem.difficulty == 'hard'
+        assert problem.category == 'update'
+
+    def test_patch_problem_should_return_404_for_nonexistent_problem(self):
+        payload = {'title': 'Updated'}
+
+        response = client.patch('/11111111-1111-1111-1111-111111111111/', json=payload)
+
+        assert response.status_code == 404
+        assert response.json()['detail'] == 'Problem not found'
+
+    def test_patch_problem_should_return_422_for_invalid_difficulty(self, problem):
+        payload = {'difficulty': 'impossible'}
+
+        response = client.patch(f"/{problem.id}/", json=payload)
+
+        assert response.status_code in (400, 422)
+
+    def test_delete_problem_should_return_404_for_nonexistent_problem(self):
+        response = client.delete('/11111111-1111-1111-1111-111111111111/')
+
+        assert response.status_code == 404

--- a/tests/problems/test_problem_api.py
+++ b/tests/problems/test_problem_api.py
@@ -110,7 +110,8 @@ class TestProblemApi:
 
         assert problem.is_active is False
         assert Problem.objects.count() == 1
-        
+        assert Problem.objects.filter(id=problem.id).exists()
+
     def test_patch_problem_should_update_selected_fields(self, problem):
         payload = {
             'title': 'Updated title',
@@ -144,9 +145,27 @@ class TestProblemApi:
 
         response = client.patch(f"/{problem.id}/", json=payload)
 
-        assert response.status_code in (400, 422)
+        assert response.status_code == 422
 
     def test_delete_problem_should_return_404_for_nonexistent_problem(self):
         response = client.delete('/11111111-1111-1111-1111-111111111111/')
 
         assert response.status_code == 404
+
+    def test_get_inactive_problem_should_return_404(self, problem):
+        problem.is_active = False
+        problem.save()
+
+        response = client.get(f"/{problem.id}/")
+
+        assert response.status_code == 404
+
+    def test_delete_problem_should_return_204_for_inactive_problem(self, problem):
+        problem.is_active = False
+        problem.save()
+
+        response = client.delete(f"/{problem.id}/")
+
+        assert response.status_code == 204
+        problem.refresh_from_db()
+        assert problem.is_active is False

--- a/tests/problems/test_problem_repositories.py
+++ b/tests/problems/test_problem_repositories.py
@@ -1,0 +1,83 @@
+import pytest
+from django.core.exceptions import ValidationError
+from apps.problems.models import Problem
+from apps.problems.repositories import ProblemRepository
+
+
+@pytest.mark.django_db
+class TestProblemRepository:
+    def test_get_active_by_id_should_return_only_active_problem(self, problem: Problem):
+        assert problem.is_active is True
+
+        found = ProblemRepository.get_active_by_id(problem.id)
+
+        assert found == problem
+
+    def test_get_active_by_id_should_raise_for_inactive_problem(self, problem: Problem):
+        problem.is_active = False
+        problem.save()
+
+        with pytest.raises(Problem.DoesNotExist):
+            ProblemRepository.get_active_by_id(problem.id)
+
+    def test_get_by_id_should_return_active_or_inactive_problem(self, problem: Problem):
+        inactive = Problem.objects.create(
+            title='Inactive problem',
+            description='Inactive',
+            difficulty='Easy',
+            category='arrays',
+            is_active=False,
+        )
+
+        assert ProblemRepository.get_by_id(problem.id) == problem
+        assert ProblemRepository.get_by_id(inactive.id) == inactive
+
+    def test_list_active_should_return_only_active_problems(self):
+        active = Problem.objects.create(
+            title="Active",
+            description="Active",
+            difficulty="easy",
+            category="arrays",
+            is_active=True,
+        )
+        Problem.objects.create(
+            title="Inactive",
+            description="Inactive",
+            difficulty="medium",
+            category="strings",
+            is_active=False,
+        )
+
+        result = ProblemRepository.list_active()
+
+        assert len(result) == 1
+        assert result[0] == active
+
+    def test_save_should_run_full_clean(self):
+        problem = Problem(
+            title="Invalid",
+            description="Too short",
+            difficulty="invalid_difficulty",
+            category="arrays",
+            is_active=True,
+        )
+
+        with pytest.raises(ValidationError):
+            ProblemRepository.save(problem)
+
+    def test_update_should_only_allow_whitelisted_fields(self):
+        problem = Problem.objects.create(
+            title="Original",
+            description="Original",
+            difficulty="easy",
+            category="arrays",
+            is_active=True,
+        )
+
+        allowed_update = {'title': 'New title', 'difficulty': 'medium'}
+        updated = ProblemRepository.update(problem, **allowed_update)
+        assert updated.title == 'New title'
+        assert updated.difficulty == 'medium'
+
+        with pytest.raises(ValueError):
+            ProblemRepository.update(problem, disallowed_field='oops')

--- a/tests/problems/test_problem_services.py
+++ b/tests/problems/test_problem_services.py
@@ -105,6 +105,6 @@ class TestProblemService:
         assert problem.difficulty == 'hard'
 
     def test_delete_problem_should_deactivate_problem(self, problem: Problem):
-        ProblemService.deactivate_problem(problem=problem)
+        ProblemService.deactivate_problem(problem_id=problem.id)
         problem.refresh_from_db()
         assert problem.is_active is False

--- a/tests/problems/test_problem_services.py
+++ b/tests/problems/test_problem_services.py
@@ -105,7 +105,8 @@ class TestProblemService:
         problem.refresh_from_db()
         assert problem.difficulty == 'hard'
 
-    def test_delete_problem_should_deactivate_problem(self, problem: Problem):
-        ProblemService.deactivate_problem(problem_id=problem.id)
+    def test_deactivate_problem_should_set_is_active_false(self, problem: Problem):
+        assert problem.is_active is True
+        ProblemService.deactivate_problem(problem)
         problem.refresh_from_db()
         assert problem.is_active is False


### PR DESCRIPTION
- Added PATCH /api/problems/{id}/ endpoint to partially update a problem.
- Added DELETE /api/problems/{id}/ endpoint to safely deactivate a problem.
- Extended problem repository and service layers with update and deactivate operations.
- Added API tests.

Related:
- Closes #11 
- Closes #13 
- Closes #14 
- Closes #15
- Closes #16