### PR TITLE
Endpoints for Submission

### DIFF
--- a/apps/problems/api.py
+++ b/apps/problems/api.py
@@ -2,8 +2,6 @@ from uuid import UUID
 from ninja import Router, Status
 from django.core.exceptions import ValidationError
 from ninja.errors import HttpError
-from .models import Problem
-from .schemas import ProblemSchema, ProblemCreateSchema, ProblemUpdateSchema
 from apps.problems.exceptions import ProblemNotFound
 from .schemas import ProblemSchema, ProblemCreateSchema, ProblemUpdateSchema
 from .services import ProblemService

--- a/apps/problems/repositories.py
+++ b/apps/problems/repositories.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from django.db.models import QuerySet
 from apps.problems.models import Problem
 
 
@@ -10,7 +11,7 @@ class ProblemRepository:
         return problem
 
     @staticmethod
-    def list_active():
+    def list_active() -> QuerySet[Problem]:
         return Problem.objects.filter(is_active=True)
 
     @staticmethod

--- a/apps/problems/services.py
+++ b/apps/problems/services.py
@@ -1,4 +1,5 @@
 from uuid import UUID
+from django.db.models import QuerySet
 from django.core.exceptions import ValidationError
 from apps.problems.exceptions import ProblemNotFound
 from .models import Problem, DIFFICULTY_CHOICES
@@ -55,7 +56,7 @@ class ProblemService:
         ProblemRepository.deactivate(problem)
 
     @staticmethod
-    def get_all_problems():
+    def get_all_problems() -> QuerySet[Problem]:
         return ProblemRepository.list_active()
 
     @staticmethod

--- a/apps/submissions/api.py
+++ b/apps/submissions/api.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 from ninja import Router, Status
 from ninja.errors import HttpError
+from django.core.exceptions import ValidationError
 
 from apps.problems.exceptions import ProblemNotFound
 from .models import Submission
@@ -10,15 +11,15 @@ from .services import SubmissionService
 router = Router()
 
 
-@router.get('/submissions/{submission_id}/', response=SubmissionSchema)
+@router.get("/submissions/{submission_id}/", response=SubmissionSchema)
 def get_submission(request, submission_id: UUID):
     try:
         return SubmissionService.get_submission_by_id(submission_id)
     except Submission.DoesNotExist:
-        raise HttpError(404, 'Submission not found')
+        raise HttpError(404, "Submission not found")
 
 
-@router.post('/problems/{problem_id}/submissions/', response={201: SubmissionSchema})
+@router.post("/problems/{problem_id}/submissions/", response={201: SubmissionSchema})
 def create_submission(request, problem_id: UUID, data: SubmissionCreateSchema):
     try:
         submission = SubmissionService.create_submission(
@@ -28,9 +29,11 @@ def create_submission(request, problem_id: UUID, data: SubmissionCreateSchema):
         )
         return Status(201, submission)
     except ProblemNotFound:
-        raise HttpError(404, 'Problem not found')
+        raise HttpError(404, "Problem not found")
+    except ValidationError as e:
+        raise HttpError(422, e.messages[0])
 
 
-@router.get('/problems/{problem_id}/submissions/', response=list[SubmissionSchema])
+@router.get("/problems/{problem_id}/submissions/", response=list[SubmissionSchema])
 def get_submissions_for_problem(request, problem_id: UUID):
     return SubmissionService.get_submissions_for_problem(problem_id)

--- a/apps/submissions/api.py
+++ b/apps/submissions/api.py
@@ -1,0 +1,36 @@
+from uuid import UUID
+from ninja import Router, Status
+from ninja.errors import HttpError
+
+from apps.problems.exceptions import ProblemNotFound
+from .models import Submission
+from .schemas import SubmissionSchema, SubmissionCreateSchema
+from .services import SubmissionService
+
+router = Router()
+
+
+@router.get('/submissions/{submission_id}/', response=SubmissionSchema)
+def get_submission(request, submission_id: UUID):
+    try:
+        return SubmissionService.get_submission_by_id(submission_id)
+    except Submission.DoesNotExist:
+        raise HttpError(404, 'Submission not found')
+
+
+@router.post('/problems/{problem_id}/submissions/', response={201: SubmissionSchema})
+def create_submission(request, problem_id: UUID, data: SubmissionCreateSchema):
+    try:
+        submission = SubmissionService.create_submission(
+            user=request.user,
+            problem_id=problem_id,
+            code=data.code,
+        )
+        return Status(201, submission)
+    except ProblemNotFound:
+        raise HttpError(404, 'Problem not found')
+
+
+@router.get('/problems/{problem_id}/submissions/', response=list[SubmissionSchema])
+def get_submissions_for_problem(request, problem_id: UUID):
+    return SubmissionService.get_submissions_for_problem(problem_id)

--- a/apps/submissions/repositories.py
+++ b/apps/submissions/repositories.py
@@ -1,0 +1,39 @@
+from uuid import UUID
+from django.db.models import QuerySet
+
+from apps.problems.models import Problem
+from apps.users.models import User
+from apps.submissions.models import Submission
+
+
+class SubmissionRepository:
+
+    @staticmethod
+    def save(submission: Submission):
+        submission.full_clean()
+        submission.save()
+        return submission
+
+    @staticmethod
+    def create(
+            user: User,
+            problem: Problem,
+            code: str,
+            status: str = "PENDING",
+
+    ) -> Submission:
+        submission = Submission(
+            user=user,
+            problem=problem,
+            code=code,
+            status=status,
+        )
+        return SubmissionRepository.save(submission)
+
+    @staticmethod
+    def get_by_id(submission_id: UUID) -> Submission:
+        return Submission.objects.get(id=submission_id)
+
+    @staticmethod
+    def get_submissions_for_problem(problem_id: UUID) -> QuerySet[Submission]:
+        return Submission.objects.filter(problem_id=problem_id).order_by('-created_at')

--- a/apps/submissions/schemas.py
+++ b/apps/submissions/schemas.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from uuid import UUID
+from typing import Literal
+from ninja import Schema
+
+
+class SubmissionSchema(Schema):
+    id: UUID
+    user_id: int
+    problem_id: UUID
+    code: str
+    created_at: datetime
+    status: Literal["PENDING", "DONE", "WRONG_ANSWER", "ERROR"]
+
+
+class SubmissionCreateSchema(Schema):
+    code: str

--- a/apps/submissions/services.py
+++ b/apps/submissions/services.py
@@ -1,7 +1,14 @@
+from uuid import UUID
+
 from django.core.exceptions import ValidationError
+from django.db.models import QuerySet
+
 from .models import Submission
 from apps.problems.models import Problem
 from apps.users.models import User
+from .repositories import SubmissionRepository
+from apps.problems.repositories import ProblemRepository
+from apps.problems.exceptions import ProblemNotFound
 
 STATUS_CHOICES_SUBMISSION = Submission.Status.values
 
@@ -10,7 +17,7 @@ class SubmissionService:
     @staticmethod
     def create_submission(
             user: User,
-            problem: Problem,
+            problem_id: UUID,
             code: str,
             status=None
     ) -> Submission:
@@ -20,12 +27,22 @@ class SubmissionService:
         if not code.strip():
             raise ValidationError('Code cannot be empty')
 
-        submission = Submission.objects.create(
+        try:
+            problem = ProblemRepository.get_active_by_id(problem_id)
+        except Problem.DoesNotExist as exc:
+            raise ProblemNotFound('Problem not found') from exc
+
+        return SubmissionRepository.create(
             user=user,
             problem=problem,
             code=code,
             status=status,
         )
-        submission.full_clean()
-        submission.save()
-        return submission
+
+    @staticmethod
+    def get_submission_by_id(submission_id: UUID) -> Submission:
+        return SubmissionRepository.get_by_id(submission_id)
+
+    @staticmethod
+    def get_submissions_for_problem(problem_id: UUID) -> QuerySet[Submission]:
+        return SubmissionRepository.get_submissions_for_problem(problem_id)

--- a/apps/test_cases/repositories.py
+++ b/apps/test_cases/repositories.py
@@ -1,4 +1,4 @@
-import uuid
+from uuid import UUID
 from django.db.models import QuerySet
 from .models import TestCase
 from apps.problems.models import Problem
@@ -27,9 +27,9 @@ class TestCaseRepository:
         return TestCaseRepository.save(test_case)
 
     @staticmethod
-    def get_test_cases_for_problem(problem_id: uuid.UUID) -> QuerySet[TestCase]:
-        return TestCase.objects.filter(problem_id=problem_id).order_by("id")
+    def get_test_cases_for_problem(problem_id: UUID) -> QuerySet[TestCase]:
+        return TestCase.objects.filter(problem_id=problem_id).order_by('id')
 
     @staticmethod
-    def get_by_id(test_case_id: uuid.UUID) -> TestCase:
+    def get_by_id(test_case_id: UUID) -> TestCase:
         return TestCase.objects.get(id=test_case_id)

--- a/apps/test_cases/repositories.py
+++ b/apps/test_cases/repositories.py
@@ -13,22 +13,22 @@ class TestCaseRepository:
 
     @staticmethod
     def create(
-            problem: Problem,
-            input_data: str,
-            expected_output: str,
-            is_hidden: bool = False
+        problem: Problem, 
+        input_data: str, 
+        expected_output: str, 
+        is_hidden: bool = False
     ) -> TestCase:
         test_case = TestCase(
             problem=problem,
             input_data=input_data,
             expected_output=expected_output,
-            is_hidden=is_hidden
+            is_hidden=is_hidden,
         )
         return TestCaseRepository.save(test_case)
 
     @staticmethod
     def get_test_cases_for_problem(problem_id: UUID) -> QuerySet[TestCase]:
-        return TestCase.objects.filter(problem_id=problem_id).order_by('id')
+        return TestCase.objects.filter(problem_id=problem_id).order_by("id")
 
     @staticmethod
     def get_by_id(test_case_id: UUID) -> TestCase:

--- a/config/api.py
+++ b/config/api.py
@@ -1,8 +1,9 @@
 from ninja import NinjaAPI
 from apps.problems.api import router as problems_router
 from apps.test_cases.api import router as test_cases_router
-
+from apps.submissions.api import router as submissions_router
 api = NinjaAPI(title="Lopa API")
 
 api.add_router('/problems', problems_router)
 api.add_router('', test_cases_router)
+api.add_router('', submissions_router)

--- a/tests/submissions/test_submission_api.py
+++ b/tests/submissions/test_submission_api.py
@@ -13,70 +13,72 @@ client = TestClient(router)
 class TestSubmissionApi:
     def test_get_submission_should_return_200(self, user, problem):
         submission = Submission.objects.create(
-            user=user,
-            problem=problem,
-            code='[1,2,3]',
-            status='PENDING'
+            user=user, problem=problem, code="[1,2,3]", status="PENDING"
         )
 
-        response = client.get(f'/submissions/{submission.id}/')
+        response = client.get(f"/submissions/{submission.id}/")
 
         assert response.status_code == 200
 
     def test_get_submission_should_return_submission_data(self, user, problem):
         submission = Submission.objects.create(
-            user=user,
-            problem=problem,
-            code='[1,2,3]',
-            status='PENDING'
+            user=user, problem=problem, code="[1,2,3]", status="PENDING"
         )
 
-        response = client.get(f'/submissions/{submission.id}/')
+        response = client.get(f"/submissions/{submission.id}/")
 
         data = response.json()
 
-        assert data['id'] == str(submission.id)
-        assert data['problem_id'] == str(problem.id)
-        assert data['user_id'] == user.id
+        assert data["id"] == str(submission.id)
+        assert data["problem_id"] == str(problem.id)
+        assert data["user_id"] == user.id
 
     def test_get_submission_should_return_404_for_non_existing_submission(self):
         non_existent_id = uuid.uuid4()
 
-        response = client.get(f'/submissions/{non_existent_id}/')
+        response = client.get(f"/submissions/{non_existent_id}/")
 
         assert response.status_code == 404
-        assert response.json()['detail'] == 'Submission not found'
+        assert response.json()["detail"] == "Submission not found"
 
     def test_create_submission_should_return_201(self, user, problem, monkeypatch):
         payload = {
-            'code': '[1,2,3]',
+            "code": "[1,2,3]",
         }
 
-        response = client.post(f'/problems/{problem.id}/submissions/', json=payload, user=user)
+        response = client.post(
+            f"/problems/{problem.id}/submissions/", json=payload, user=user
+        )
 
         assert response.status_code == 201
         data = response.json()
-        assert data['problem_id'] == str(problem.id)
-        assert data['status'] == 'PENDING'
-        assert data['created_at'] is not None
+        assert data["problem_id"] == str(problem.id)
+        assert data["status"] == "PENDING"
+        assert data["created_at"] is not None
 
-    def test_create_submission_should_return_404_when_problem_does_not_exist(self, user):
+    def test_create_submission_should_return_404_when_problem_does_not_exist(
+        self, user
+    ):
         payload = {
-            'code': '[1,2,3]',
+            "code": "[1,2,3]",
         }
         non_existent_problem_id = uuid.uuid4()
 
-        response = client.post(f'/problems/{non_existent_problem_id}/submissions/', json=payload, user=user)
+        response = client.post(
+            f"/problems/{non_existent_problem_id}/submissions/", json=payload, user=user
+        )
 
         assert response.status_code == 404
-        assert response.json()['detail'] == 'Problem not found'
+        assert response.json()["detail"] == "Problem not found"
 
     def test_should_create_submission_in_database(self, user, problem):
         payload = {
-            'code': '[1,2,3]',
+            "code": "[1,2,3]",
         }
 
-        response = client.post(f'/problems/{problem.id}/submissions/', json=payload, user=user)
+        response = client.post(
+            f"/problems/{problem.id}/submissions/", json=payload, user=user
+        )
 
         assert response.status_code == 201
         assert Submission.objects.count() == 1
@@ -84,30 +86,38 @@ class TestSubmissionApi:
         submission = Submission.objects.first()
         assert submission.user == user
         assert submission.problem == problem
-        assert submission.code == '[1,2,3]'
+        assert submission.code == "[1,2,3]"
 
-    def test_get_submissions_for_problem_should_return_submissions_in_order(self, user, problem):
+    def test_get_submissions_for_problem_should_return_submissions_in_order(
+        self, user, problem
+    ):
         first_submission = Submission.objects.create(
-            user=user,
-            problem=problem,
-            code='[1,2,3]',
-            status='PENDING'
+            user=user, problem=problem, code="[1,2,3]", status="PENDING"
         )
         second_submission = Submission.objects.create(
-            user=user,
-            problem=problem,
-            code='[4,5,6]',
-            status='PENDING'
+            user=user, problem=problem, code="[4,5,6]", status="PENDING"
         )
 
-        response = client.get(f'/problems/{problem.id}/submissions/')
+        response = client.get(f"/problems/{problem.id}/submissions/")
 
         assert response.status_code == 200
         data = response.json()
 
         assert len(data) == 2
-        assert data[0]['id'] == str(second_submission.id)
-        assert data[1]['id'] == str(first_submission.id)
+        assert data[0]["id"] == str(second_submission.id)
+        assert data[1]["id"] == str(first_submission.id)
 
-        assert data[0]['code'] == '[4,5,6]'
-        assert data[1]['code'] == '[1,2,3]'
+        assert data[0]["code"] == "[4,5,6]"
+        assert data[1]["code"] == "[1,2,3]"
+
+    def test_create_submission_with_empty_code_should_return_422(self, user, problem):
+        payload = {"problem_id": str(problem.id), "code": "  "}
+
+        response = client.post(
+            f"/problems/{problem.id}/submissions/",
+            json=payload,
+            user=user,
+        )
+
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Code cannot be empty"

--- a/tests/submissions/test_submission_api.py
+++ b/tests/submissions/test_submission_api.py
@@ -1,0 +1,113 @@
+import pytest
+import uuid
+
+from ninja.testing import TestClient
+
+from apps.submissions.api import router
+from apps.submissions.models import Submission
+
+client = TestClient(router)
+
+
+@pytest.mark.django_db
+class TestSubmissionApi:
+    def test_get_submission_should_return_200(self, user, problem):
+        submission = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]',
+            status='PENDING'
+        )
+
+        response = client.get(f'/submissions/{submission.id}/')
+
+        assert response.status_code == 200
+
+    def test_get_submission_should_return_submission_data(self, user, problem):
+        submission = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]',
+            status='PENDING'
+        )
+
+        response = client.get(f'/submissions/{submission.id}/')
+
+        data = response.json()
+
+        assert data['id'] == str(submission.id)
+        assert data['problem_id'] == str(problem.id)
+        assert data['user_id'] == user.id
+
+    def test_get_submission_should_return_404_for_non_existing_submission(self):
+        non_existent_id = uuid.uuid4()
+
+        response = client.get(f'/submissions/{non_existent_id}/')
+
+        assert response.status_code == 404
+        assert response.json()['detail'] == 'Submission not found'
+
+    def test_create_submission_should_return_201(self, user, problem, monkeypatch):
+        payload = {
+            'code': '[1,2,3]',
+        }
+
+        response = client.post(f'/problems/{problem.id}/submissions/', json=payload, user=user)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data['problem_id'] == str(problem.id)
+        assert data['status'] == 'PENDING'
+        assert data['created_at'] is not None
+
+    def test_create_submission_should_return_404_when_problem_does_not_exist(self, user):
+        payload = {
+            'code': '[1,2,3]',
+        }
+        non_existent_problem_id = uuid.uuid4()
+
+        response = client.post(f'/problems/{non_existent_problem_id}/submissions/', json=payload, user=user)
+
+        assert response.status_code == 404
+        assert response.json()['detail'] == 'Problem not found'
+
+    def test_should_create_submission_in_database(self, user, problem):
+        payload = {
+            'code': '[1,2,3]',
+        }
+
+        response = client.post(f'/problems/{problem.id}/submissions/', json=payload, user=user)
+
+        assert response.status_code == 201
+        assert Submission.objects.count() == 1
+
+        submission = Submission.objects.first()
+        assert submission.user == user
+        assert submission.problem == problem
+        assert submission.code == '[1,2,3]'
+
+    def test_get_submissions_for_problem_should_return_submissions_in_order(self, user, problem):
+        first_submission = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]',
+            status='PENDING'
+        )
+        second_submission = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]',
+            status='PENDING'
+        )
+
+        response = client.get(f'/problems/{problem.id}/submissions/')
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data) == 2
+        assert data[0]['id'] == str(second_submission.id)
+        assert data[1]['id'] == str(first_submission.id)
+
+        assert data[0]['code'] == '[4,5,6]'
+        assert data[1]['code'] == '[1,2,3]'

--- a/tests/submissions/test_submission_repositories.py
+++ b/tests/submissions/test_submission_repositories.py
@@ -1,0 +1,117 @@
+import uuid
+import pytest
+from apps.submissions.models import Submission
+from apps.submissions.repositories import SubmissionRepository
+from apps.problems.models import Problem
+
+
+@pytest.mark.django_db
+class TestSubmissionRepository:
+    def test_create_should_return_saved_submission(self, user, problem):
+        submission = SubmissionRepository.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]',
+        )
+
+        assert submission.id is not None
+        assert submission.user == user
+        assert submission.problem == problem
+        assert submission.code == '[4,5,6]'
+        assert submission.status == Submission.Status.PENDING
+
+    def test_gest_submissions_for_problem_should_return_all_submissions(self, user, problem):
+        Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]'
+        )
+        Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]'
+        )
+
+        queryset = SubmissionRepository.get_submissions_for_problem(problem.id)
+        assert queryset.count() == 2
+        code = {tc.code for tc in queryset}
+        assert code == {'[1,2,3]', '[4,5,6]'}
+
+    def test_get_by_id_should_return_submission(self, user, problem):
+        created = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]',
+        )
+
+        submission = SubmissionRepository.get_by_id(created.id)
+        assert submission == created
+        assert submission.status == Submission.Status.PENDING
+
+    def test_get_submissions_for_problem_should_not_include_other_problem_submissions(self, user, problem):
+        other_problem = Problem.objects.create()
+
+        first = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]',
+        )
+        second = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]',
+        )
+        other_submission = Submission.objects.create(
+            user=user,
+            problem=other_problem,
+            code='[7,8,9]',
+        )
+
+        submissions = list(SubmissionRepository.get_submissions_for_problem(problem.id))
+
+        assert len(submissions) == 2
+        assert first in submissions
+        assert second in submissions
+        assert other_submission not in submissions
+
+    def test_get_submissions_for_problem_should_return_submissions_by_created_at(self, user, problem):
+        first = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]',
+        )
+        second = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]',
+        )
+
+        submissions = list(
+            SubmissionRepository.get_submissions_for_problem(problem.id)
+        )
+
+        assert submissions[0].id == second.id
+        assert submissions[1].id == first.id
+
+    def test_get_submissions_for_problem_should_return_submissions_ordered_by_created_at_desc(self, user, problem):
+        first = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[1,2,3]',
+        )
+        second = Submission.objects.create(
+            user=user,
+            problem=problem,
+            code='[4,5,6]',
+        )
+
+        submissions = list(
+            SubmissionRepository.get_submissions_for_problem(problem.id)
+        )
+        assert len(submissions) == 2
+        assert submissions[0] == second
+        assert submissions[1] == first
+
+    def test_get_by_id_raises_does_not_exist(self):
+        with pytest.raises(Submission.DoesNotExist):
+            SubmissionRepository.get_by_id(uuid.uuid4())

--- a/tests/submissions/test_submission_services.py
+++ b/tests/submissions/test_submission_services.py
@@ -9,7 +9,7 @@ class TestSubmissionService:
     def test_create_submission_should_set_correct_fields(self, user, problem):
         new_submission = SubmissionService.create_submission(
             user=user,
-            problem=problem,
+            problem_id=problem.id,
             code='print("Hello World")',
         )
         assert new_submission.user == user
@@ -22,7 +22,7 @@ class TestSubmissionService:
 
         submission = SubmissionService.create_submission(
             user=user,
-            problem=problem,
+            problem_id=problem.id,
             code=code
         )
 
@@ -34,7 +34,7 @@ class TestSubmissionService:
         with pytest.raises(Exception):
             SubmissionService.create_submission(
                 user=None,
-                problem=problem,
+                problem_id=problem,
                 code='print(1)'
             )
 
@@ -42,7 +42,7 @@ class TestSubmissionService:
         initial_count = Submission.objects.count()
 
         with pytest.raises(ValidationError):
-            SubmissionService.create_submission(user=user, problem=problem, code=" ")
+            SubmissionService.create_submission(user=user, problem_id=problem, code=" ")
 
         assert Submission.objects.count() == initial_count
 
@@ -50,7 +50,7 @@ class TestSubmissionService:
         with pytest.raises(ValidationError):
             SubmissionService.create_submission(
                 user=user,
-                problem=problem,
+                problem_id=problem,
                 code='print("Hello World")',
                 status='SUPER_INVALID_STATUS'
             )


### PR DESCRIPTION
- Added GET /api/submissions/{id}/ endpoint to return submission details.
- Added GET /api/problems/{problem_id}/submissions/ endpoint to return all submissions for a problem.
- Added POST /api/problems/{problem_id}/submissions/ endpoint to create a new submission.
- Extended submission repository and service layers with create, get by id, and list by problem operations.
- Added schemas and API, service, and repository tests for submissions.

Related:
- Closes #23 
- Closes #26 
- Closes #27 