### PR TITLE
Endpoints for Result

### DIFF
--- a/apps/results/api.py
+++ b/apps/results/api.py
@@ -1,0 +1,24 @@
+from uuid import UUID
+from ninja import Router
+from ninja.errors import HttpError
+
+from .models import Result
+from .schemas import ResultSchema
+from .services import ResultService
+
+router = Router()
+
+
+@router.get('results/{result_id}/', response=ResultSchema)
+def get_result(request, result_id: UUID):
+    try:
+        return ResultService.get_result_by_id(result_id)
+    except Result.DoesNotExist:
+        raise HttpError(404, 'Result does not exist')
+
+
+@router.get(
+    'submissions/{submission_id}/results/', response=list[ResultSchema]
+)
+def get_results_for_submission(request, submission_id: UUID):
+    return ResultService.get_results_for_submission(submission_id)

--- a/apps/results/repositories.py
+++ b/apps/results/repositories.py
@@ -1,0 +1,39 @@
+from uuid import UUID
+from django.db.models import QuerySet
+
+from .models import Result
+from apps.test_cases.models import TestCase
+from apps.submissions.models import Submission
+
+
+class ResultRepository:
+    @staticmethod
+    def save(result: Result) -> Result:
+        result.full_clean()
+        result.save()
+        return result
+
+    @staticmethod
+    def create(
+        submission: Submission,
+        test_case: TestCase,
+        actual_output: str,
+        execution_time: float,
+        status: str = Result.Status.PENDING,
+    ) -> Result:
+        result = Result(
+            submission=submission,
+            test_case=test_case,
+            actual_output=actual_output,
+            execution_time=execution_time,
+            status=status,
+        )
+        return ResultRepository.save(result)
+
+    @staticmethod
+    def get_by_id(result_id: UUID) -> Result:
+        return Result.objects.get(id=result_id)
+
+    @staticmethod
+    def get_results_for_submission(submission_id: UUID) -> QuerySet[Result]:
+        return Result.objects.filter(submission_id=submission_id)

--- a/apps/results/schemas.py
+++ b/apps/results/schemas.py
@@ -11,7 +11,6 @@ class ResultSchema(Schema):
         'PENDING',
         'PASSED',
         'WRONG_ANSWER',
-        'ERROR',
         'TIME_LIMIT_EXCEEDED',
         'RUNTIME_ERROR',
     ]

--- a/apps/results/schemas.py
+++ b/apps/results/schemas.py
@@ -1,0 +1,19 @@
+from uuid import UUID
+from typing import Literal
+from ninja import Schema
+
+
+class ResultSchema(Schema):
+    id: UUID
+    submission_id: UUID
+    test_case_id: UUID
+    status: Literal[
+        'PENDING',
+        'PASSED',
+        'WRONG_ANSWER',
+        'ERROR',
+        'TIME_LIMIT_EXCEEDED',
+        'RUNTIME_ERROR',
+    ]
+    actual_output: str | None = None
+    execution_time: float | None = None

--- a/apps/results/services.py
+++ b/apps/results/services.py
@@ -1,5 +1,9 @@
+from uuid import UUID
 from django.core.exceptions import ValidationError
+from django.db.models import QuerySet
+
 from .models import Result
+from .repositories import ResultRepository
 from apps.test_cases.models import TestCase
 from apps.submissions.models import Submission
 
@@ -9,14 +13,16 @@ STATUS_CHOICES_RESULT = Result.Status.values
 class ResultService:
     @staticmethod
     def create_result(
-            submission: Submission,
-            test_case: TestCase,
-            actual_output: str = "",
-            execution_time: float = 0.0,
-            status: str = None
+        submission: Submission,
+        test_case: TestCase,
+        actual_output: str = '',
+        execution_time: float = 0.0,
+        status: str | None = None,
     ) -> Result:
+        if status is not None and status not in STATUS_CHOICES_RESULT:
+            raise ValidationError('Invalid status level')
 
-        result = Result(
+        return ResultRepository.create(
             submission=submission,
             test_case=test_case,
             status=status or Result.Status.PENDING,
@@ -24,17 +30,12 @@ class ResultService:
             execution_time=execution_time,
         )
 
-        result.full_clean()
-
-        result.save()
-        return result
-
     @staticmethod
     def update_result(
-            result: Result,
-            status: str | None = None,
-            actual_output: str | None = None,
-            execution_time: float | None = None
+        result: Result,
+        status: str | None = None,
+        actual_output: str | None = None,
+        execution_time: float | None = None,
     ) -> Result:
         if status is not None and status not in STATUS_CHOICES_RESULT:
             raise ValidationError('Invalid status level')
@@ -46,5 +47,12 @@ class ResultService:
         if execution_time is not None:
             result.execution_time = execution_time
 
-        result.save()
-        return result
+        return ResultRepository.save(result)
+
+    @staticmethod
+    def get_results_for_submission(submission_id: UUID) -> QuerySet[Result]:
+        return ResultRepository.get_results_for_submission(submission_id)
+
+    @staticmethod
+    def get_result_by_id(result_id: UUID) -> Result:
+        return ResultRepository.get_by_id(result_id)

--- a/config/api.py
+++ b/config/api.py
@@ -1,8 +1,10 @@
 from ninja import NinjaAPI
 from apps.problems.api import router as problems_router
 from apps.test_cases.api import router as test_cases_router
+from apps.results.api import router as results_router
 
-api = NinjaAPI(title="Lopa API")
+api = NinjaAPI(title='Lopa API')
 
 api.add_router('/problems', problems_router)
 api.add_router('', test_cases_router)
+api.add_router('', results_router)

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,7 @@ def user(db):
     return User.objects.create_user(
         username='Adam',
         email='adam@gmail.com',
-        password='testpassword123'
+        password='testpassword123',
     )
 
 
@@ -51,4 +51,20 @@ def result(db, submission, test_case):
         test_case=test_case,
         actual_output='123',
         execution_time=0.2,
+    )
+
+
+@pytest.fixture
+def other_result(user, problem, test_case):
+    other_submission = Submission.objects.create(
+        user=user,
+        problem=problem,
+        code='print(2)',
+    )
+    return Result.objects.create(
+        submission=other_submission,
+        test_case=test_case,
+        status=Result.Status.WRONG_ANSWER,
+        actual_output='wrong answer',
+        execution_time=0.02,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,9 @@ dev = [
     "pytest-cov>=7.1.0",
     "pytest-django>=4.12.0",
 ]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.ruff]
+line-length = 79

--- a/tests/results/test_result_api.py
+++ b/tests/results/test_result_api.py
@@ -1,0 +1,49 @@
+import pytest
+from ninja.testing import TestClient
+
+from apps.results.api import router
+
+client = TestClient(router)
+
+
+@pytest.mark.django_db
+class TestResultApi:
+    def test_get_result_should_return_single_result(self, result):
+        response = client.get(f'/results/{result.id}/')
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data['id'] == str(result.id)
+        assert data['submission_id'] == str(result.submission_id)
+        assert data['test_case_id'] == str(result.test_case_id)
+        assert data['status'] == result.status
+        assert data['actual_output'] == result.actual_output
+        assert data['execution_time'] == result.execution_time
+
+    def test_get_result_should_return_404_for_nonexistent_result(self):
+        response = client.get('/results/11111111-1111-1111-1111-111111111111/')
+
+        assert response.status_code == 404
+        assert response.json()['detail'] == 'Result does not exist'
+
+    def test_get_results_for_submission_should_return_only_submission_results(
+        self, submission, result, other_result
+    ):
+        response = client.get(f'/submissions/{submission.id}/results/')
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data) == 1
+        assert data[0]['id'] == str(result.id)
+        assert data[0]['submission_id'] == str(submission.id)
+        assert data[0]['test_case_id'] == str(result.test_case_id)
+
+    def test_get_results_for_submission_should_return_empty_list_when_no_results(
+        self, submission
+    ):
+        response = client.get(f'/submissions/{submission.id}/results/')
+
+        assert response.status_code == 200
+        assert response.json() == []

--- a/tests/results/test_result_repositories.py
+++ b/tests/results/test_result_repositories.py
@@ -1,0 +1,51 @@
+import pytest
+from uuid import UUID
+
+from apps.results.models import Result
+from apps.results.repositories import ResultRepository
+
+
+@pytest.mark.django_db
+class TestResultRepository:
+    def test_get_by_id_should_return_result(self, result):
+        found_result = ResultRepository.get_by_id(result.id)
+
+        assert found_result.id == result.id
+        assert found_result.submission_id == result.submission_id
+        assert found_result.test_case_id == result.test_case_id
+        assert found_result.status == result.status
+
+    def test_get_results_for_submission_should_return_only_submission_results(
+        self, submission, other_result, result
+    ):
+        results = ResultRepository.get_results_for_submission(submission.id)
+
+        assert results.count() == 1
+        assert result in results
+        assert other_result not in results
+
+    def test_create_should_create_result_with_given_data(
+        self, submission, test_case
+    ):
+        created = ResultRepository.create(
+            submission=submission,
+            test_case=test_case,
+            actual_output='42',
+            execution_time=0.12,
+            status=Result.Status.PENDING,
+        )
+
+        assert created.id is not None
+        assert created.submission == submission
+        assert created.test_case == test_case
+        assert created.actual_output == '42'
+        assert created.execution_time == 0.12
+        assert created.status == Result.Status.PENDING
+
+    def test_get_by_id_should_raise_does_not_exist_for_nonexistent_result(
+        self,
+    ):
+        nonexistent_id = UUID('11111111-1111-1111-1111-111111111111')
+
+        with pytest.raises(Result.DoesNotExist):
+            ResultRepository.get_by_id(nonexistent_id)


### PR DESCRIPTION
- Added GET /api/results/{result_id}/ endpoint to return single result details.
- Added GET /api/submissions/{submission_id}/results/ endpoint to return all results for a submission.
- Extended result repository and service layers with get by id and list by submission operations.
- Updated result schemas for read endpoints.
- Tests have been added that successfully passed for the repository and the results API.

Related:
- Closes #20 
- Closes #21 
