### PR TITLE
Frontend for result

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -6,22 +6,34 @@ Lopa/
 │   ├── problems/               # Domain: Problem management
 │   │   ├── migrations/
 │   │   ├── models.py           # Problem model
-│   │   ├── services.py         # Business logic (ProblemService)
+│   │   ├── api.py              # Django Ninja endpoints
+│   │   ├── repositories.py     # Data access and queries
+│   │   ├── schemas.py          # API schemas / validation
+│   │   ├── services.py         # Business logic
 │   │   └── ...
 │   ├── results/                # Domain: Evaluation & status tracking
 │   │   ├── migrations/
 │   │   ├── models.py           # Result model
-│   │   ├── services.py         # Business logic (ResultService)
+│   │   ├── api.py              # Django Ninja endpoints
+│   │   ├── repositories.py     # Data access and queries
+│   │   ├── schemas.py          # API schemas / validation
+│   │   ├── services.py         # Business logic
 │   │   └── ...
 │   ├── submissions/            # Domain: User code submissions
 │   │   ├── migrations/
 │   │   ├── models.py           # Submission model
-│   │   ├── services.py         # Business logic (SubmissionService)
+│   │   ├── api.py              # Django Ninja endpoints
+│   │   ├── repositories.py     # Data access and queries
+│   │   ├── schemas.py          # API schemas / validation
+│   │   ├── services.py         # Business logic
 │   │   └── ...
 │   ├── test_cases/             # Domain: Test data management
 │   │   ├── migrations/
 │   │   ├── models.py           # TestCase model
-│   │   ├── services.py         # Business logic (TestCaseService)
+│   │   ├── api.py              # Django Ninja endpoints
+│   │   ├── repositories.py     # Data access and queries
+│   │   ├── schemas.py          # API schemas / validation
+│   │   ├── services.py         # Business logic
 │   │   └── ...
 │   └── users/                  # Domain: User profiles & auth
 │       ├── migrations/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Lopa (from the Polish "łopatologicznie" meaning straightforward or down-to-eart
 ### 🛠 Technologies:
 * **Language:** Python 3.13+ (via `uv`)
 * **Framework:** Django 6.0.x
+* **API Layer:** Django Ninja
+* **Schemas / Validation:** Django Ninja Schema (Pydantic-based)
 * **Package Manager:** uv (Extremely fast Python package installer and resolver)
 * **Database:** SQLite (dev/local)
 * **Testing:** Pytest 9.0.x with Pytest-Django
@@ -39,6 +41,7 @@ uv sync
 
 ### 2. Database configuration and startup
 You don't need to manually activate the virtual environment; uv run handles it for you.
+Lopa uses **Django** for the web application and **Django Ninja** for the API layer.
 ```bash
 # Run migrations
 uv run manage.py migrate 
@@ -48,16 +51,24 @@ uv run manage.py runserver
 ```
 
 The app is available at: `http://127.0.0.1:8000/`
+API documentation will be available at: `http://127.0.0.1:8000/api/docs`
 
 ## Data Architecture:
 The system is based on the logical interconnection of four pillars:
 
 | Model | Description                                                                        |
 | :--- |-----------------------------------------------------------------------------| 
-| **Problem** | Challenge definition: includes the task description, requirements specification, and assigned difficulty level.                            |
-| **TestCase** | Datasets: input vs. expected output.               |
-| **Submission** | The user's ID and their current status in the queue.                            |
-| **Result** | Detailed execution report: execution time and error messages for a single test. |
+| **Problem** | Challenge definition: includes the task description, requirements specification, and assigned difficulty level, and associated test cases.                            |
+| **TestCase** | Datasets: input vs. expected output for automated verification.               |
+| **Submission** | User solution: contains user code, associated problem, current status (`PENDING`, `DONE`, `WRONG_ANSWER`, `ERROR`), and evaluation results.                            |
+| **Result** | Test execution report: status per test case (`PASSED`, `WRONG_ANSWER`, `RUNTIME_ERROR`, etc.), execution time, and `actual_output`. |
+
+## API structure
+
+- `problems/` — problems management and public problem views
+- `submissions/` — create and fetch submissions
+- `results/` — fetch submission/test results
+- `test_cases/` — problem test cases
 
 ## Automated Testing
 The project prioritizes reliability, using uv to orchestrate tests using pytest.
@@ -69,8 +80,12 @@ uv run pytest
 uv run pytest -v
 ```
 ## Test Structure:
-- `tests/test_problems.py` – model and relationship validation.
-- `tests/test_engine.py` – code verification tests.
+The test suite is organized by application modules to reflect the project structure and keep tests easier to maintain.
+`tests/test_problems.py` – tests for the `Problem` model, validations, and problem-related logic.
+- `tests/test_test_cases.py` – tests for the `TestCase` creation, relationships, and expected input/output data.
+- `tests/test_submissions.py` – tests for the `Submission` creation, evaluation flow, and submission status updates.
+- `tests/test_results.py` – tests for `Result` creation and result status handling.
+- `tests/test_users.py` – tests for user-related models and logic.
 - `conftest.py` – common test data (fixtures).
 
 ## Project Roadmap:

--- a/apps/problems/repositories.py
+++ b/apps/problems/repositories.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from django.db.models import QuerySet
+from typing import Optional
 from apps.problems.models import Problem
 
 
@@ -11,16 +12,23 @@ class ProblemRepository:
         return problem
 
     @staticmethod
+    def _get_optional(**filters) -> Optional[Problem]:
+        try:
+            return Problem.objects.get(**filters)
+        except Problem.DoesNotExist:
+            return None
+
+    @staticmethod
     def list_active() -> QuerySet[Problem]:
         return Problem.objects.filter(is_active=True)
 
     @staticmethod
-    def get_by_id(problem_id: UUID) -> Problem:
-        return Problem.objects.get(id=problem_id)
+    def get_by_id(problem_id: UUID) -> Optional[Problem]:
+        return ProblemRepository._get_optional(id=problem_id)
 
     @staticmethod
-    def get_active_by_id(problem_id: UUID) -> Problem:
-        return Problem.objects.get(id=problem_id, is_active=True)
+    def get_active_by_id(problem_id: UUID) -> Optional[Problem]:
+        return ProblemRepository._get_optional(id=problem_id, is_active=True)
 
     @staticmethod
     def update(problem: Problem, **fields) -> Problem:
@@ -31,7 +39,9 @@ class ProblemRepository:
 
         for field, value in fields.items():
             if field not in allowed_fields:
-                raise ValueError(f'Field {field} is not allowed to be updated.')
+                raise ValueError(
+                    f'Field {field} is not allowed to be updated.'
+                )
             # Apply only fields provided by the service layer.
             setattr(problem, field, value)
 

--- a/apps/problems/services.py
+++ b/apps/problems/services.py
@@ -11,10 +11,7 @@ VALID_DIFFICULTY_KEYS = {choice[0] for choice in DIFFICULTY_CHOICES}
 class ProblemService:
     @staticmethod
     def create_problem(
-            title: str,
-            description: str,
-            difficulty: str,
-            category: str
+        title: str, description: str, difficulty: str, category: str
     ) -> Problem:
         if difficulty not in VALID_DIFFICULTY_KEYS:
             raise ValidationError('Invalid difficulty level')
@@ -23,18 +20,18 @@ class ProblemService:
             title=title,
             description=description,
             difficulty=difficulty,
-            category=category
+            category=category,
         )
 
         return ProblemRepository.save(problem)
 
     @staticmethod
     def update_problem(
-            problem: Problem,
-            title: str | None = None,
-            description: str | None = None,
-            difficulty: str | None = None,
-            category: str | None = None,
+        problem: Problem,
+        title: str | None = None,
+        description: str | None = None,
+        difficulty: str | None = None,
+        category: str | None = None,
     ) -> Problem:
         if difficulty is not None and difficulty not in VALID_DIFFICULTY_KEYS:
             raise ValidationError('Invalid difficulty level')
@@ -61,14 +58,16 @@ class ProblemService:
 
     @staticmethod
     def get_problem_by_id(problem_id: UUID) -> Problem:
-        try:
-            return ProblemRepository.get_active_by_id(problem_id)
-        except Problem.DoesNotExist as exc:
-            raise ProblemNotFound('Problem not found') from exc
+        problem = ProblemRepository.get_active_by_id(problem_id)
+        if not problem:
+            raise ProblemNotFound('Problem not found')
+
+        return problem
 
     @staticmethod
     def get_problem_for_update_or_delete(problem_id: UUID) -> Problem:
-        try:
-            return ProblemRepository.get_by_id(problem_id)
-        except Problem.DoesNotExist as exc:
-            raise ProblemNotFound('Problem not found') from exc
+        problem = ProblemRepository.get_by_id(problem_id)
+        if not problem:
+            raise ProblemNotFound('Problem not found')
+
+        return problem

--- a/apps/problems/templates/problems/problem_detail.html
+++ b/apps/problems/templates/problems/problem_detail.html
@@ -13,10 +13,12 @@
 		<h1 class="text-2xl md:text-3xl font-bold mb-4">{{ problem.title }}</h1>
 
 		<div class="flex flex-wrap gap-2 mb-4 text-sm">
-			<span class="rounded bg-gray-100 px-3 py-1"
-				>{{ problem.difficulty }}</span
-			>
-			<span class="rounded bg-gray-100 px-3 py-1">{{ problem.category }}</span>
+			<span class="rounded bg-gray-100 px-3 py-1">
+				{{ problem.difficulty }}
+			</span>
+			<span class="rounded bg-gray-100 px-3 py-1">
+				{{ problem.category }}
+			</span>
 		</div>
 
 		<p class="text-gray-700 whitespace-pre-line">{{ problem.description }}</p>
@@ -42,13 +44,21 @@
 			<button
 				type="submit"
 				id="submit-btn"
-				class="rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 transition"
+				class="rounded-lg bg-blue-600 px-4 py-2 text-white font-medium hover:bg-blue-700 transition disabled:opacity-60 disabled:cursor-not-allowed"
 			>
 				Submit
 			</button>
-
-			<p id="submission-status" class="text-sm"></p>
 		</form>
+
+		<div
+			id="submission-feedback"
+			class="mt-4 hidden rounded-lg border p-4"
+		></div>
+
+		<div id="results-container" class="mt-6 hidden">
+			<h3 class="text-lg font-semibold mb-3">Results</h3>
+			<div id="results-list" class="space-y-3"></div>
+		</div>
 	</div>
 </div>
 
@@ -56,26 +66,151 @@
 	const form = document.getElementById("submission-form");
 	const codeInput = document.getElementById("code-input");
 	const submitBtn = document.getElementById("submit-btn");
-	const statusEl = document.getElementById("submission-status");
+	const feedbackEl = document.getElementById("submission-feedback");
+	const resultsContainer = document.getElementById("results-container");
+	const resultsList = document.getElementById("results-list");
 	const csrfToken = document.querySelector("[name=csrfmiddlewaretoken]").value;
+
+	function showFeedback(message, type = "info") {
+		feedbackEl.classList.remove("hidden");
+		feedbackEl.className = "mt-4 rounded-lg border p-4";
+
+		if (type === "success") {
+			feedbackEl.classList.add(
+				"bg-green-50",
+				"border-green-200",
+				"text-green-700",
+			);
+		} else if (type === "error") {
+			feedbackEl.classList.add("bg-red-50", "border-red-200", "text-red-700");
+		} else if (type === "warning") {
+			feedbackEl.classList.add(
+				"bg-yellow-50",
+				"border-yellow-200",
+				"text-yellow-700",
+			);
+		} else {
+			feedbackEl.classList.add(
+				"bg-gray-50",
+				"border-gray-200",
+				"text-gray-700",
+			);
+		}
+
+		feedbackEl.innerHTML = message;
+	}
+
+	function hideResults() {
+		resultsContainer.classList.add("hidden");
+		resultsList.innerHTML = "";
+	}
+
+	function renderResults(results, submissionId, submissionStatus) {
+		resultsContainer.classList.remove("hidden");
+
+		if (!results.length) {
+			resultsList.innerHTML = `
+                <div class="rounded-lg border border-yellow-200 bg-yellow-50 p-4 text-yellow-700">
+                    <p class="font-medium">Submission created, but results are not available yet.</p>
+                    <p class="mt-1 text-sm">Submission status: ${submissionStatus ?? "UNKNOWN"}</p>
+                    <a
+                        href="/results/submissions/${submissionId}/results/"
+                        class="inline-flex items-center mt-3 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 transition"
+                    >
+                        Open results page
+                    </a>
+                </div>
+            `;
+			return;
+		}
+
+		resultsList.innerHTML = `
+            <div class="space-y-3">
+                ${results
+									.map((result, index) => {
+										const status = result.status ?? "UNKNOWN";
+										const executionTime = result.execution_time ?? "-";
+										const testCaseId =
+											result.test_case_id ?? result.test_case?.id ?? "-";
+
+										let badgeClasses = "bg-yellow-100 text-yellow-800";
+										if (status === "PASSED") {
+											badgeClasses = "bg-green-100 text-green-800";
+										} else if (status === "FAILED") {
+											badgeClasses = "bg-red-100 text-red-800";
+										}
+
+										return `
+                        <div class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+                            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                                <div>
+                                    <p class="font-semibold text-gray-900">Result ${index + 1}</p>
+                                    <p class="text-sm text-gray-600 mt-1">Test case ID: ${testCaseId}</p>
+                                    <p class="text-sm text-gray-600">Execution time: ${executionTime}</p>
+                                </div>
+                                <span class="inline-flex w-fit items-center rounded-full px-3 py-1 text-sm font-medium ${badgeClasses}">
+                                    ${status}
+                                </span>
+                            </div>
+                        </div>
+                    `;
+									})
+									.join("")}
+                <div>
+                    <a
+                        href="/results/submissions/${submissionId}/results/"
+                        class="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 transition"
+                    >
+                        Open results page
+                    </a>
+                </div>
+            </div>
+        `;
+	}
+
+	async function fetchJson(response) {
+		const contentType = response.headers.get("content-type") || "";
+		if (!contentType.includes("application/json")) {
+			return null;
+		}
+		return await response.json();
+	}
+
+	async function loadResults(submissionId, submissionStatus) {
+		const resultsResponse = await fetch(
+			`/api/submissions/${submissionId}/results/`,
+			{
+				method: "GET",
+				headers: {
+					Accept: "application/json",
+				},
+			},
+		);
+
+		const resultsData = await fetchJson(resultsResponse);
+
+		if (!resultsResponse.ok) {
+			throw new Error("Could not load results.");
+		}
+
+		renderResults(resultsData || [], submissionId, submissionStatus);
+	}
 
 	form.addEventListener("submit", async function (event) {
 		event.preventDefault();
 
 		const code = codeInput.value.trim();
 
+		hideResults();
+
 		if (!code) {
-			statusEl.textContent = "Code cannot be empty.";
-			statusEl.className =
-				"mt-2 rounded bg-red-50 px-3 py-2 text-sm text-red-700";
+			showFeedback("Code cannot be empty.", "error");
 			return;
 		}
 
 		submitBtn.disabled = true;
 		submitBtn.textContent = "Submitting...";
-		statusEl.textContent = "Submitting solution...";
-		statusEl.className =
-			"mt-2 rounded bg-gray-50 px-3 py-2 text-sm text-gray-700";
+		showFeedback("Submitting solution...", "info");
 
 		try {
 			const response = await fetch(
@@ -93,22 +228,27 @@
 				},
 			);
 
-			const contentType = response.headers.get("content-type") || "";
-			const isJson = contentType.includes("application/json");
-			const data = isJson ? await response.json() : null;
+			const data = await fetchJson(response);
 
 			if (!response.ok) {
 				throw new Error(data?.detail || data?.message || "Submission failed.");
 			}
 
-			statusEl.textContent = `Submission created successfully. Status: ${data.status}.`;
-			statusEl.className =
-				"mt-2 rounded bg-green-50 px-3 py-2 text-sm text-green-700";
+			showFeedback(
+				`
+                    <div class="space-y-1">
+                        <p class="font-medium">Submission created successfully.</p>
+                        <p class="text-sm">Submission status: ${data?.status ?? "UNKNOWN"}</p>
+                        <p class="text-sm">Submission ID: ${data?.id ?? "-"}</p>
+                    </div>
+                `,
+				"success",
+			);
+
+			await loadResults(data.id, data.status);
 			codeInput.value = "";
 		} catch (error) {
-			statusEl.textContent = error.message || "Something went wrong.";
-			statusEl.className =
-				"mt-2 rounded bg-red-50 px-3 py-2 text-sm text-red-700";
+			showFeedback(error.message || "Something went wrong.", "error");
 		} finally {
 			submitBtn.disabled = false;
 			submitBtn.textContent = "Submit";

--- a/apps/problems/templates/problems/problem_detail.html
+++ b/apps/problems/templates/problems/problem_detail.html
@@ -136,8 +136,13 @@
 										let badgeClasses = "bg-yellow-100 text-yellow-800";
 										if (status === "PASSED") {
 											badgeClasses = "bg-green-100 text-green-800";
-										} else if (status === "FAILED") {
+										} else if (
+											status === "WRONG_ANSWER" ||
+											status === "RUNTIME_ERROR"
+										) {
 											badgeClasses = "bg-red-100 text-red-800";
+										} else if (status === "TIME_LIMIT_EXCEEDED") {
+											badgeClasses = "bg-orange-100 text-orange-800";
 										}
 
 										return `

--- a/apps/problems/urls.py
+++ b/apps/problems/urls.py
@@ -6,4 +6,5 @@ app_name = 'problems'
 urlpatterns = [
     path('', ProblemListView.as_view(), name='problems_list'),
     path('<uuid:problem_id>/', ProblemDetailView.as_view(), name='problem_detail')
+   
     ]

--- a/apps/problems/views.py
+++ b/apps/problems/views.py
@@ -5,8 +5,8 @@ from .models import Problem
 
 class ProblemListView(LoginRequiredMixin, ListView):
     model = Problem
-    template_name = "problems/problem_list.html"
-    context_object_name = "problems"
+    template_name = 'problems/problem_list.html'
+    context_object_name = 'problems'
 
     def get_queryset(self):
         return Problem.objects.filter(is_active=True)
@@ -14,9 +14,9 @@ class ProblemListView(LoginRequiredMixin, ListView):
 
 class ProblemDetailView(LoginRequiredMixin, DetailView):
     model = Problem
-    template_name = "problems/problem_detail.html"
-    context_object_name = "problem"
-    pk_url_kwarg = "problem_id"
+    template_name = 'problems/problem_detail.html'
+    context_object_name = 'problem'
+    pk_url_kwarg = 'problem_id'
 
     def get_queryset(self):
         return Problem.objects.filter(is_active=True)

--- a/apps/results/repositories.py
+++ b/apps/results/repositories.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from django.db.models import QuerySet
+from typing import Optional
 
 from .models import Result
 from apps.test_cases.models import TestCase
@@ -31,8 +32,11 @@ class ResultRepository:
         return ResultRepository.save(result)
 
     @staticmethod
-    def get_by_id(result_id: UUID) -> Result:
-        return Result.objects.get(id=result_id)
+    def get_by_id(result_id: UUID) -> Optional[Result]:
+        try:
+            return Result.objects.get(id=result_id)
+        except Result.DoesNotExist:
+            return None
 
     @staticmethod
     def get_results_for_submission(submission_id: UUID) -> QuerySet[Result]:

--- a/apps/results/services.py
+++ b/apps/results/services.py
@@ -55,4 +55,9 @@ class ResultService:
 
     @staticmethod
     def get_result_by_id(result_id: UUID) -> Result:
-        return ResultRepository.get_by_id(result_id)
+        result = ResultRepository.get_by_id(result_id)
+
+        if not result:
+            raise Result.DoesNotExist(f'Result with id {result_id} not found')
+
+        return result

--- a/apps/results/templates/results/submission_results.html
+++ b/apps/results/templates/results/submission_results.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+
+{% block title %}LOPA | Submission Results{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-surface-container-low p-6 lg:p-12">
+    <div class="max-w-4xl mx-auto">
+        <div class="mb-8">
+            <h1 class="text-3xl font-extrabold text-on-surface tracking-tight">
+                Submission Results
+            </h1>
+            {% if submission %}
+                <p class="mt-2 text-on-surface-variant font-medium">
+                    Submission ID: {{ submission.id }}
+                </p>
+            {% endif %}
+        </div>
+
+        {% if error %}
+            <div class="rounded-3xl border border-red-200 bg-red-50 p-8 shadow-sm">
+                <h2 class="text-xl font-bold text-red-700">Something went wrong</h2>
+                <p class="mt-2 text-red-600">
+                    {{ error }}
+                </p>
+            </div>
+
+        {% elif results %}
+            <div class="space-y-4">
+                {% for result in results %}
+                    <div class="rounded-3xl border border-outline-variant/10 bg-surface-container-high p-6 shadow-sm">
+                        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                            <div>
+                                <h2 class="text-lg font-bold text-on-surface">
+                                    Result {{ forloop.counter }}
+                                </h2>
+                                <p class="text-sm text-on-surface-variant mt-1">
+                                    Test case ID: {{ result.test_case.id }}
+                                </p>
+                                <p class="text-sm text-on-surface-variant">
+                                    Execution time: {{ result.execution_time }}
+                                </p>
+                            </div>
+
+                           <span class="inline-flex items-center rounded-full px-4 py-2 text-sm font-bold
+    {% if result.status == 'PASSED' %}
+        bg-green-100 text-green-700
+    {% elif result.status == 'WRONG_ANSWER' or result.status == 'RUNTIME_ERROR' %}
+        bg-red-100 text-red-700
+    {% elif result.status == 'TIME_LIMIT_EXCEEDED' %}
+        bg-orange-100 text-orange-700
+    {% else %}
+        bg-yellow-100 text-yellow-700
+    {% endif %}">
+    {{ result.status }}
+</span>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+
+        {% else %}
+            <div class="rounded-3xl border border-outline-variant/10 bg-surface-container-high p-8 shadow-sm">
+                <div class="flex items-center gap-4 mb-6">
+                    <div class="w-12 h-12 rounded-2xl bg-primary/10 flex items-center justify-center">
+                        <svg class="w-6 h-6 text-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-bold text-on-surface">Results are not available yet</h2>
+                        <p class="text-sm text-on-surface-variant">
+                            This submission exists, but the test results have not been generated yet.
+                        </p>
+                    </div>
+                </div>
+
+                <div class="h-2 w-full bg-outline-variant/20 rounded-full overflow-hidden">
+                    <div class="h-full bg-primary w-1/3 animate-pulse"></div>
+                </div>
+            </div>
+        {% endif %}
+
+        <div class="mt-8">
+            <a href="{% url 'home' %}"
+               class="inline-flex items-center gap-2 px-6 py-3 bg-primary text-on-primary rounded-full font-bold hover:shadow-lg transition-all">
+                Back
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/apps/results/urls.py
+++ b/apps/results/urls.py
@@ -1,0 +1,12 @@
+from django.urls import path
+from .views import ResultListView
+
+app_name = 'results'
+
+urlpatterns = [
+    path(
+        'submissions/<uuid:submission_id>/results/',
+        ResultListView.as_view(),
+        name='submission_results',
+    ),
+]

--- a/apps/results/views.py
+++ b/apps/results/views.py
@@ -1,3 +1,23 @@
-from django.shortcuts import render
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import ListView
+from .models import Result
+from apps.submissions.models import Submission
 
-# Create your views here.
+
+class ResultListView(LoginRequiredMixin, ListView):
+    model = Result
+    template_name = 'results/submission_results.html'
+    context_object_name = 'results'
+
+    def get_queryset(self):
+        submission_id = self.kwargs['submission_id']
+        return Result.objects.filter(submission_id=submission_id).order_by(
+            'id'
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['submission'] = Submission.objects.get(
+            id=self.kwargs['submission_id']
+        )
+        return context

--- a/apps/results/views.py
+++ b/apps/results/views.py
@@ -1,6 +1,8 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import ListView
+from django.http import Http404
 from .models import Result
+from apps.submissions.services import SubmissionService
 from apps.submissions.models import Submission
 
 
@@ -17,7 +19,11 @@ class ResultListView(LoginRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['submission'] = Submission.objects.get(
-            id=self.kwargs['submission_id']
-        )
+        try:
+            context['submission'] = SubmissionService.get_submission_by_id(
+                self.kwargs['submission_id']
+            )
+        except Submission.DoesNotExist:
+            raise Http404('Submission not found')
+
         return context

--- a/apps/submissions/models.py
+++ b/apps/submissions/models.py
@@ -13,17 +13,17 @@ class Submission(models.Model):
     id = models.UUIDField(
         primary_key=True,
         default=uuid.uuid4,
-        editable=False
+        editable=False,
     )
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
-        related_name='submissions'
+        related_name='submissions',
     )
     problem = models.ForeignKey(
         'problems.Problem',
         on_delete=models.CASCADE,
-        related_name='submissions'
+        related_name='submissions',
     )
     code = models.TextField()
     created_at = models.DateTimeField(auto_now_add=True)

--- a/apps/submissions/repositories.py
+++ b/apps/submissions/repositories.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from django.db.models import QuerySet
+from typing import Optional
 
 from apps.problems.models import Problem
 from apps.users.models import User
@@ -7,7 +8,6 @@ from apps.submissions.models import Submission
 
 
 class SubmissionRepository:
-
     @staticmethod
     def save(submission: Submission):
         submission.full_clean()
@@ -16,11 +16,10 @@ class SubmissionRepository:
 
     @staticmethod
     def create(
-            user: User,
-            problem: Problem,
-            code: str,
-            status: str = "PENDING",
-
+        user: User,
+        problem: Problem,
+        code: str,
+        status: str = 'PENDING',
     ) -> Submission:
         submission = Submission(
             user=user,
@@ -31,9 +30,14 @@ class SubmissionRepository:
         return SubmissionRepository.save(submission)
 
     @staticmethod
-    def get_by_id(submission_id: UUID) -> Submission:
-        return Submission.objects.get(id=submission_id)
+    def get_by_id(submission_id: UUID) -> Optional[Submission]:
+        try:
+            return Submission.objects.get(id=submission_id)
+        except Submission.DoesNotExist:
+            return None
 
     @staticmethod
     def get_submissions_for_problem(problem_id: UUID) -> QuerySet[Submission]:
-        return Submission.objects.filter(problem_id=problem_id).order_by('-created_at')
+        return Submission.objects.filter(problem_id=problem_id).order_by(
+            '-created_at'
+        )

--- a/apps/submissions/services.py
+++ b/apps/submissions/services.py
@@ -25,10 +25,9 @@ class SubmissionService:
         if not code.strip():
             raise ValidationError('Code cannot be empty')
 
-        try:
-            problem = ProblemRepository.get_active_by_id(problem_id)
-        except Problem.DoesNotExist as exc:
-            raise ProblemNotFound('Problem not found') from exc
+        problem = ProblemRepository.get_active_by_id(problem_id)
+        if not problem:
+            raise ProblemNotFound('Problem not found')
 
         submission = SubmissionRepository.create(
             user=user,
@@ -38,11 +37,18 @@ class SubmissionService:
         )
         SubmissionEvaluationService.evaluate(submission)
 
-        return SubmissionRepository.get_by_id(submission.id)
+        return submission
 
     @staticmethod
     def get_submission_by_id(submission_id: UUID) -> Submission:
-        return SubmissionRepository.get_by_id(submission_id)
+        submission = SubmissionRepository.get_by_id(submission_id)
+
+        if not submission:
+            raise Submission.DoesNotExist(
+                f'Submission {submission_id} not found'
+            )
+
+        return submission
 
     @staticmethod
     def get_submissions_for_problem(problem_id: UUID) -> QuerySet[Submission]:

--- a/apps/submissions/services.py
+++ b/apps/submissions/services.py
@@ -9,6 +9,7 @@ from apps.users.models import User
 from .repositories import SubmissionRepository
 from apps.problems.repositories import ProblemRepository
 from apps.problems.exceptions import ProblemNotFound
+from .status_services import SubmissionEvaluationService
 
 STATUS_CHOICES_SUBMISSION = Submission.Status.values
 
@@ -16,10 +17,7 @@ STATUS_CHOICES_SUBMISSION = Submission.Status.values
 class SubmissionService:
     @staticmethod
     def create_submission(
-            user: User,
-            problem_id: UUID,
-            code: str,
-            status=None
+        user: User, problem_id: UUID, code: str, status=None
     ) -> Submission:
         if status is None:
             status = Submission.Status.PENDING
@@ -32,12 +30,15 @@ class SubmissionService:
         except Problem.DoesNotExist as exc:
             raise ProblemNotFound('Problem not found') from exc
 
-        return SubmissionRepository.create(
+        submission = SubmissionRepository.create(
             user=user,
             problem=problem,
             code=code,
             status=status,
         )
+        SubmissionEvaluationService.evaluate(submission)
+
+        return SubmissionRepository.get_by_id(submission.id)
 
     @staticmethod
     def get_submission_by_id(submission_id: UUID) -> Submission:

--- a/apps/submissions/status_services.py
+++ b/apps/submissions/status_services.py
@@ -1,0 +1,73 @@
+from apps.results.models import Result
+from apps.results.repositories import ResultRepository
+from .models import Submission
+from .repositories import SubmissionRepository
+
+
+class SubmissionStatusService:
+    @staticmethod
+    def resolve(results: list[Result]) -> str:
+        if not results:
+            return Submission.Status.PENDING
+
+        statuses = [result.status for result in results]
+
+        if any(status == Result.Status.RUNTIME_ERROR for status in statuses):
+            return Submission.Status.ERROR
+
+        if any(
+            status == Result.Status.TIME_LIMIT_EXCEEDED for status in statuses
+        ):
+            return Submission.Status.ERROR
+
+        if any(status == Result.Status.WRONG_ANSWER for status in statuses):
+            return Submission.Status.WRONG_ANSWER
+
+        if all(status == Result.Status.PASSED for status in statuses):
+            return Submission.Status.DONE
+
+        return Submission.Status.PENDING
+
+
+class SubmissionEvaluationService:
+    @staticmethod
+    def evaluate(submission: Submission) -> Submission:
+        test_cases = submission.problem.test_cases.all().order_by('id')
+
+        if not test_cases.exists():
+            submission.status = Submission.Status.ERROR
+            return SubmissionRepository.save(submission)
+
+        created_results = []
+
+        for test_case in test_cases:
+            code = submission.code.strip()
+            expected_output = test_case.expected_output.strip()
+
+            if 'error' in code.lower():
+                result_status = Result.Status.RUNTIME_ERROR
+                actual_output = 'Runtime Error: Invalid code'
+            elif 'timeout' in code.lower():
+                result_status = Result.Status.TIME_LIMIT_EXCEEDED
+                actual_output = 'Time Limit Exceeded'
+
+            elif code == expected_output:
+                result_status = Result.Status.PASSED
+                actual_output = code
+            else:
+                result_status = Result.Status.WRONG_ANSWER
+                actual_output = code
+
+            result = ResultRepository.create(
+                submission=submission,
+                test_case=test_case,
+                actual_output=actual_output,
+                execution_time=0.1
+                if result_status == Result.Status.PASSED
+                else 0.5,
+                status=result_status,
+            )
+            created_results.append(result)
+
+        submission.status = SubmissionStatusService.resolve(created_results)
+        return SubmissionRepository.save(submission)

--- a/apps/test_cases/repositories.py
+++ b/apps/test_cases/repositories.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from django.db.models import QuerySet
+from typing import Optional
 from .models import TestCase
 from apps.problems.models import Problem
 
@@ -13,10 +14,10 @@ class TestCaseRepository:
 
     @staticmethod
     def create(
-        problem: Problem, 
-        input_data: str, 
-        expected_output: str, 
-        is_hidden: bool = False
+        problem: Problem,
+        input_data: str,
+        expected_output: str,
+        is_hidden: bool = False,
     ) -> TestCase:
         test_case = TestCase(
             problem=problem,
@@ -28,8 +29,11 @@ class TestCaseRepository:
 
     @staticmethod
     def get_test_cases_for_problem(problem_id: UUID) -> QuerySet[TestCase]:
-        return TestCase.objects.filter(problem_id=problem_id).order_by("id")
+        return TestCase.objects.filter(problem_id=problem_id).order_by('id')
 
     @staticmethod
-    def get_by_id(test_case_id: UUID) -> TestCase:
-        return TestCase.objects.get(id=test_case_id)
+    def get_by_id(test_case_id: UUID) -> Optional[TestCase]:
+        try:
+            return TestCase.objects.get(id=test_case_id)
+        except TestCase.DoesNotExist:
+            return None

--- a/apps/test_cases/services.py
+++ b/apps/test_cases/services.py
@@ -13,15 +13,15 @@ from .repositories import TestCaseRepository
 class TestCaseService:
     @staticmethod
     def create_test_case(
-            problem_id: UUID,
-            input_data: str,
-            expected_output: str,
-            is_hidden: bool = False
+        problem_id: UUID,
+        input_data: str,
+        expected_output: str,
+        is_hidden: bool = False,
     ) -> TestCase:
-        try:
-            problem = ProblemRepository.get_active_by_id(problem_id)
-        except Problem.DoesNotExist as exc:
-            raise ProblemNotFound('Problem not found') from exc
+
+        problem = ProblemRepository.get_active_by_id(problem_id)
+        if not problem:
+            raise ProblemNotFound('Problem not found')
 
         return TestCaseRepository.create(
             problem=problem,
@@ -31,9 +31,14 @@ class TestCaseService:
         )
 
     @staticmethod
-    def get_test_cases_for_problem(problem_id: uuid.UUID) -> QuerySet[TestCase]:
+    def get_test_cases_for_problem(
+        problem_id: uuid.UUID,
+    ) -> QuerySet[TestCase]:
         return TestCaseRepository.get_test_cases_for_problem(problem_id)
 
     @staticmethod
     def get_test_case_by_id(test_case_id: uuid.UUID) -> TestCase:
-        return TestCaseRepository.get_by_id(test_case_id)
+        test_case = TestCaseRepository.get_by_id(test_case_id)
+        if not test_case:
+            raise TestCase.DoesNotExist('TestCase {test_case_id} not found')
+        return test_case

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,8 +20,9 @@ from django.urls import path, include
 from .api import api
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("api/", api.urls),
-    path("", include("apps.users.urls")),
-    path("problems/", include("apps.problems.urls")),
+    path('admin/', admin.site.urls),
+    path('api/', api.urls),
+    path('', include('apps.users.urls')),
+    path('problems/', include('apps.problems.urls')),
+    path('results/', include('apps.results.urls')),
 ]

--- a/tests/problems/test_problem_repositories.py
+++ b/tests/problems/test_problem_repositories.py
@@ -6,21 +6,28 @@ from apps.problems.repositories import ProblemRepository
 
 @pytest.mark.django_db
 class TestProblemRepository:
-    def test_get_active_by_id_should_return_only_active_problem(self, problem: Problem):
+    def test_get_active_by_id_should_return_only_active_problem(
+        self, problem: Problem
+    ):
         assert problem.is_active is True
 
         found = ProblemRepository.get_active_by_id(problem.id)
 
         assert found == problem
 
-    def test_get_active_by_id_should_raise_for_inactive_problem(self, problem: Problem):
+    def test_get_active_by_id_should_raise_for_inactive_problem(
+        self, problem: Problem
+    ):
         problem.is_active = False
         problem.save()
 
-        with pytest.raises(Problem.DoesNotExist):
-            ProblemRepository.get_active_by_id(problem.id)
+        problem = ProblemRepository.get_active_by_id(problem.id)
 
-    def test_get_by_id_should_return_active_or_inactive_problem(self, problem: Problem):
+        assert problem is None
+
+    def test_get_by_id_should_return_active_or_inactive_problem(
+        self, problem: Problem
+    ):
         inactive = Problem.objects.create(
             title='Inactive problem',
             description='Inactive',
@@ -34,17 +41,17 @@ class TestProblemRepository:
 
     def test_list_active_should_return_only_active_problems(self):
         active = Problem.objects.create(
-            title="Active",
-            description="Active",
-            difficulty="easy",
-            category="arrays",
+            title='Active',
+            description='Active',
+            difficulty='easy',
+            category='arrays',
             is_active=True,
         )
         Problem.objects.create(
-            title="Inactive",
-            description="Inactive",
-            difficulty="medium",
-            category="strings",
+            title='Inactive',
+            description='Inactive',
+            difficulty='medium',
+            category='strings',
             is_active=False,
         )
 
@@ -55,10 +62,10 @@ class TestProblemRepository:
 
     def test_save_should_run_full_clean(self):
         problem = Problem(
-            title="Invalid",
-            description="Too short",
-            difficulty="invalid_difficulty",
-            category="arrays",
+            title='Invalid',
+            description='Too short',
+            difficulty='invalid_difficulty',
+            category='arrays',
             is_active=True,
         )
 
@@ -67,10 +74,10 @@ class TestProblemRepository:
 
     def test_update_should_only_allow_whitelisted_fields(self):
         problem = Problem.objects.create(
-            title="Original",
-            description="Original",
-            difficulty="easy",
-            category="arrays",
+            title='Original',
+            description='Original',
+            difficulty='easy',
+            category='arrays',
             is_active=True,
         )
 

--- a/tests/results/test_result_repositories.py
+++ b/tests/results/test_result_repositories.py
@@ -47,5 +47,6 @@ class TestResultRepository:
     ):
         nonexistent_id = UUID('11111111-1111-1111-1111-111111111111')
 
-        with pytest.raises(Result.DoesNotExist):
-            ResultRepository.get_by_id(nonexistent_id)
+        result = ResultRepository.get_by_id(nonexistent_id)
+
+        assert result is None

--- a/tests/submissions/test_submission_api.py
+++ b/tests/submissions/test_submission_api.py
@@ -13,71 +13,81 @@ client = TestClient(router)
 class TestSubmissionApi:
     def test_get_submission_should_return_200(self, user, problem):
         submission = Submission.objects.create(
-            user=user, problem=problem, code="[1,2,3]", status="PENDING"
+            user=user, problem=problem, code='[1,2,3]', status='PENDING'
         )
 
-        response = client.get(f"/submissions/{submission.id}/")
+        response = client.get(f'/submissions/{submission.id}/')
 
         assert response.status_code == 200
 
     def test_get_submission_should_return_submission_data(self, user, problem):
         submission = Submission.objects.create(
-            user=user, problem=problem, code="[1,2,3]", status="PENDING"
+            user=user, problem=problem, code='[1,2,3]', status='PENDING'
         )
 
-        response = client.get(f"/submissions/{submission.id}/")
+        response = client.get(f'/submissions/{submission.id}/')
 
         data = response.json()
 
-        assert data["id"] == str(submission.id)
-        assert data["problem_id"] == str(problem.id)
-        assert data["user_id"] == user.id
+        assert data['id'] == str(submission.id)
+        assert data['problem_id'] == str(problem.id)
+        assert data['user_id'] == user.id
 
-    def test_get_submission_should_return_404_for_non_existing_submission(self):
+    def test_get_submission_should_return_404_for_non_existing_submission(
+        self,
+    ):
         non_existent_id = uuid.uuid4()
 
-        response = client.get(f"/submissions/{non_existent_id}/")
+        response = client.get(f'/submissions/{non_existent_id}/')
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Submission not found"
+        assert response.json()['detail'] == 'Submission not found'
 
-    def test_create_submission_should_return_201(self, user, problem, monkeypatch):
+    def test_create_submission_should_return_201(
+        self, user, problem, monkeypatch
+    ):
+        monkeypatch.setattr(
+            'apps.submissions.status_services.SubmissionEvaluationService.evaluate',
+            lambda x: None,
+        )
         payload = {
-            "code": "[1,2,3]",
+            'code': '[1,2,3]',
         }
 
         response = client.post(
-            f"/problems/{problem.id}/submissions/", json=payload, user=user
+            f'/problems/{problem.id}/submissions/', json=payload, user=user
         )
 
         assert response.status_code == 201
         data = response.json()
-        assert data["problem_id"] == str(problem.id)
-        assert data["status"] == "PENDING"
-        assert data["created_at"] is not None
+        assert data['problem_id'] == str(problem.id)
+        assert data['status'] == 'PENDING'
+        assert data['created_at'] is not None
 
     def test_create_submission_should_return_404_when_problem_does_not_exist(
         self, user
     ):
         payload = {
-            "code": "[1,2,3]",
+            'code': '[1,2,3]',
         }
         non_existent_problem_id = uuid.uuid4()
 
         response = client.post(
-            f"/problems/{non_existent_problem_id}/submissions/", json=payload, user=user
+            f'/problems/{non_existent_problem_id}/submissions/',
+            json=payload,
+            user=user,
         )
 
         assert response.status_code == 404
-        assert response.json()["detail"] == "Problem not found"
+        assert response.json()['detail'] == 'Problem not found'
 
     def test_should_create_submission_in_database(self, user, problem):
         payload = {
-            "code": "[1,2,3]",
+            'code': '[1,2,3]',
         }
 
         response = client.post(
-            f"/problems/{problem.id}/submissions/", json=payload, user=user
+            f'/problems/{problem.id}/submissions/', json=payload, user=user
         )
 
         assert response.status_code == 201
@@ -86,38 +96,40 @@ class TestSubmissionApi:
         submission = Submission.objects.first()
         assert submission.user == user
         assert submission.problem == problem
-        assert submission.code == "[1,2,3]"
+        assert submission.code == '[1,2,3]'
 
     def test_get_submissions_for_problem_should_return_submissions_in_order(
         self, user, problem
     ):
         first_submission = Submission.objects.create(
-            user=user, problem=problem, code="[1,2,3]", status="PENDING"
+            user=user, problem=problem, code='[1,2,3]', status='PENDING'
         )
         second_submission = Submission.objects.create(
-            user=user, problem=problem, code="[4,5,6]", status="PENDING"
+            user=user, problem=problem, code='[4,5,6]', status='PENDING'
         )
 
-        response = client.get(f"/problems/{problem.id}/submissions/")
+        response = client.get(f'/problems/{problem.id}/submissions/')
 
         assert response.status_code == 200
         data = response.json()
 
         assert len(data) == 2
-        assert data[0]["id"] == str(second_submission.id)
-        assert data[1]["id"] == str(first_submission.id)
+        assert data[0]['id'] == str(second_submission.id)
+        assert data[1]['id'] == str(first_submission.id)
 
-        assert data[0]["code"] == "[4,5,6]"
-        assert data[1]["code"] == "[1,2,3]"
+        assert data[0]['code'] == '[4,5,6]'
+        assert data[1]['code'] == '[1,2,3]'
 
-    def test_create_submission_with_empty_code_should_return_422(self, user, problem):
-        payload = {"problem_id": str(problem.id), "code": "  "}
+    def test_create_submission_with_empty_code_should_return_422(
+        self, user, problem
+    ):
+        payload = {'problem_id': str(problem.id), 'code': '  '}
 
         response = client.post(
-            f"/problems/{problem.id}/submissions/",
+            f'/problems/{problem.id}/submissions/',
             json=payload,
             user=user,
         )
 
         assert response.status_code == 422
-        assert response.json()["detail"] == "Code cannot be empty"
+        assert response.json()['detail'] == 'Code cannot be empty'

--- a/tests/submissions/test_submission_repositories.py
+++ b/tests/submissions/test_submission_repositories.py
@@ -20,17 +20,11 @@ class TestSubmissionRepository:
         assert submission.code == '[4,5,6]'
         assert submission.status == Submission.Status.PENDING
 
-    def test_gest_submissions_for_problem_should_return_all_submissions(self, user, problem):
-        Submission.objects.create(
-            user=user,
-            problem=problem,
-            code='[1,2,3]'
-        )
-        Submission.objects.create(
-            user=user,
-            problem=problem,
-            code='[4,5,6]'
-        )
+    def test_gest_submissions_for_problem_should_return_all_submissions(
+        self, user, problem
+    ):
+        Submission.objects.create(user=user, problem=problem, code='[1,2,3]')
+        Submission.objects.create(user=user, problem=problem, code='[4,5,6]')
 
         queryset = SubmissionRepository.get_submissions_for_problem(problem.id)
         assert queryset.count() == 2
@@ -48,7 +42,9 @@ class TestSubmissionRepository:
         assert submission == created
         assert submission.status == Submission.Status.PENDING
 
-    def test_get_submissions_for_problem_should_not_include_other_problem_submissions(self, user, problem):
+    def test_get_submissions_for_problem_should_not_include_other_problem_submissions(
+        self, user, problem
+    ):
         other_problem = Problem.objects.create()
 
         first = Submission.objects.create(
@@ -67,14 +63,18 @@ class TestSubmissionRepository:
             code='[7,8,9]',
         )
 
-        submissions = list(SubmissionRepository.get_submissions_for_problem(problem.id))
+        submissions = list(
+            SubmissionRepository.get_submissions_for_problem(problem.id)
+        )
 
         assert len(submissions) == 2
         assert first in submissions
         assert second in submissions
         assert other_submission not in submissions
 
-    def test_get_submissions_for_problem_should_return_submissions_by_created_at(self, user, problem):
+    def test_get_submissions_for_problem_should_return_submissions_by_created_at(
+        self, user, problem
+    ):
         first = Submission.objects.create(
             user=user,
             problem=problem,
@@ -93,7 +93,9 @@ class TestSubmissionRepository:
         assert submissions[0].id == second.id
         assert submissions[1].id == first.id
 
-    def test_get_submissions_for_problem_should_return_submissions_ordered_by_created_at_desc(self, user, problem):
+    def test_get_submissions_for_problem_should_return_submissions_ordered_by_created_at_desc(
+        self, user, problem
+    ):
         first = Submission.objects.create(
             user=user,
             problem=problem,
@@ -113,5 +115,6 @@ class TestSubmissionRepository:
         assert submissions[1] == first
 
     def test_get_by_id_raises_does_not_exist(self):
-        with pytest.raises(Submission.DoesNotExist):
-            SubmissionRepository.get_by_id(uuid.uuid4())
+        submission = SubmissionRepository.get_by_id(uuid.uuid4())
+
+        assert submission is None

--- a/tests/submissions/test_submission_services.py
+++ b/tests/submissions/test_submission_services.py
@@ -15,42 +15,48 @@ class TestSubmissionService:
         assert new_submission.user == user
         assert new_submission.problem == problem
         assert new_submission.code == 'print("Hello World")'
-        assert new_submission.status == Submission.Status.PENDING
+        assert new_submission.status in Submission.Status.values
 
-    def test_create_submission_with_valid_data_should_succeed(self, user, problem):
+    def test_create_submission_with_valid_data_should_succeed(
+        self, user, problem
+    ):
         code = 'print("Hello World")'
 
         submission = SubmissionService.create_submission(
-            user=user,
-            problem_id=problem.id,
-            code=code
+            user=user, problem_id=problem.id, code=code
         )
 
         assert submission.id is not None
         assert submission.code == code
-        assert submission.status == Submission.Status.PENDING
+        assert submission.status in Submission.Status.values
 
-    def test_create_submission_should_raise_error_when_user_is_missing(self, problem):
+    def test_create_submission_should_raise_error_when_user_is_missing(
+        self, problem
+    ):
         with pytest.raises(Exception):
             SubmissionService.create_submission(
-                user=None,
-                problem_id=problem,
-                code='print(1)'
+                user=None, problem_id=problem, code='print(1)'
             )
 
-    def test_create_submission_should_not_save_on_empty_code(self, user, problem):
+    def test_create_submission_should_not_save_on_empty_code(
+        self, user, problem
+    ):
         initial_count = Submission.objects.count()
 
         with pytest.raises(ValidationError):
-            SubmissionService.create_submission(user=user, problem_id=problem, code=" ")
+            SubmissionService.create_submission(
+                user=user, problem_id=problem, code=' '
+            )
 
         assert Submission.objects.count() == initial_count
 
-    def test_create_submission_should_raise_error_on_invalid_status(self, user, problem):
+    def test_create_submission_should_raise_error_on_invalid_status(
+        self, user, problem
+    ):
         with pytest.raises(ValidationError):
             SubmissionService.create_submission(
                 user=user,
                 problem_id=problem,
                 code='print("Hello World")',
-                status='SUPER_INVALID_STATUS'
+                status='SUPER_INVALID_STATUS',
             )

--- a/tests/test_cases/test_test_case_repositories.py
+++ b/tests/test_cases/test_test_case_repositories.py
@@ -47,5 +47,6 @@ class TestTestCaseRepository:
         assert test_case == created
 
     def test_get_by_id_raises_does_not_exist(self):
-        with pytest.raises(TestCase.DoesNotExist):
-            TestCaseRepository.get_by_id(uuid.uuid4())
+        test_case = TestCaseRepository.get_by_id(uuid.uuid4())
+
+        assert test_case is None


### PR DESCRIPTION
- Added a frontend page for displaying results related to a single submission.
- Added routing and view logic for submission results.
- Added clear status badges, test case identifiers, and execution time display.
- Added an empty state for submissions without generated results.
- Added minor documentation updates in `README.md` and `Architecture.md`.

Related:
- Closes #36 
- Closes #40 